### PR TITLE
[TinyViT] Use pytorch amp to reduce training time

### DIFF
--- a/TinyViT/config.py
+++ b/TinyViT/config.py
@@ -98,7 +98,7 @@ _C.TRAIN.CLIP_GRAD = 5.0
 _C.TRAIN.AUTO_RESUME = True
 # Gradient accumulation steps
 # could be overwritten by command line argument
-_C.TRAIN.ACCUMULATION_STEPS = 0
+_C.TRAIN.ACCUMULATION_STEPS = 1
 # Whether to use gradient checkpointing to save memory
 # could be overwritten by command line argument
 _C.TRAIN.USE_CHECKPOINT = False
@@ -162,9 +162,9 @@ _C.TEST.CROP = True
 # -----------------------------------------------------------------------------
 # Misc
 # -----------------------------------------------------------------------------
-# Mixed precision opt level, if O0, no amp is used ('O0', 'O1', 'O2')
-# overwritten by command line argument
-_C.AMP_OPT_LEVEL = ''
+
+# Enable Pytorch automatic mixed precision (amp).
+_C.AMP_ENABLE = True
 # Path to output folder, overwritten by command line argument
 _C.OUTPUT = ''
 # Tag of experiment, overwritten by command line argument
@@ -218,8 +218,8 @@ def update_config(config, args):
         config.TRAIN.ACCUMULATION_STEPS = args.accumulation_steps
     if args.use_checkpoint:
         config.TRAIN.USE_CHECKPOINT = True
-    if args.amp_opt_level:
-        config.AMP_OPT_LEVEL = args.amp_opt_level
+    if args.disable_amp:
+        config.AMP_ENABLE = False
     if args.output:
         config.OUTPUT = args.output
     if args.tag:
@@ -228,8 +228,6 @@ def update_config(config, args):
         config.EVAL_MODE = True
     if args.throughput:
         config.THROUGHPUT_MODE = True
-        # we disable apex and use native amp to measure throughput
-        config.AMP_OPT_LEVEL = 'O0'
 
     # set local rank for distributed training
     if args.local_rank is None and 'LOCAL_RANK' in os.environ:

--- a/TinyViT/main.py
+++ b/TinyViT/main.py
@@ -29,9 +29,9 @@ from lr_scheduler import build_scheduler
 from optimizer import build_optimizer
 from logger import create_logger
 from utils import load_checkpoint, load_pretrained, save_checkpoint,\
-                  NativeScalerWithGradNormCount,\
-                  auto_resume_helper, is_main_process,\
-                  get_git_info, run_cmd
+    NativeScalerWithGradNormCount,\
+    auto_resume_helper, is_main_process,\
+    get_git_info, run_cmd
 
 from models.remap_layer import RemapLayer
 remap_layer_22kto1k = RemapLayer('./imagenet_1kto22k.txt')
@@ -66,7 +66,8 @@ def parse_option():
                         help="gradient accumulation steps")
     parser.add_argument('--use-checkpoint', action='store_true',
                         help="whether to use gradient checkpointing to save memory")
-    parser.add_argument('--disable_amp', action='store_true', help='Disable pytorch amp')
+    parser.add_argument('--disable_amp', action='store_true',
+                        help='Disable pytorch amp')
     parser.add_argument('--output', default='output', type=str, metavar='PATH',
                         help='root of output folder, the full path is <output>/<model_name>/<tag> (default: output)')
     parser.add_argument('--tag', help='tag of experiment')
@@ -116,7 +117,8 @@ def main(args, config):
         flops = model_without_ddp.flops()
         logger.info(f"number of GFLOPs: {flops / 1e9}")
 
-    lr_scheduler = build_scheduler(config, optimizer, len(data_loader_train) // config.TRAIN.ACCUMULATION_STEPS)
+    lr_scheduler = build_scheduler(config, optimizer, len(
+        data_loader_train) // config.TRAIN.ACCUMULATION_STEPS)
 
     if config.DISTILL.ENABLED:
         # we disable MIXUP and CUTMIX when knowledge distillation
@@ -255,13 +257,15 @@ def train_one_epoch(args, config, model, criterion, data_loader, optimizer, epoc
         loss = loss / config.TRAIN.ACCUMULATION_STEPS
 
         # this attribute is added by timm on one optimizer (adahessian)
-        is_second_order = hasattr(optimizer, 'is_second_order') and optimizer.is_second_order
+        is_second_order = hasattr(
+            optimizer, 'is_second_order') and optimizer.is_second_order
         grad_norm = loss_scaler(loss, optimizer, clip_grad=config.TRAIN.CLIP_GRAD,
                                 parameters=model.parameters(), create_graph=is_second_order,
                                 update_grad=(idx + 1) % config.TRAIN.ACCUMULATION_STEPS == 0)
         if (idx + 1) % config.TRAIN.ACCUMULATION_STEPS == 0:
             optimizer.zero_grad()
-            lr_scheduler.step_update((epoch * num_steps + idx) // config.TRAIN.ACCUMULATION_STEPS)
+            lr_scheduler.step_update(
+                (epoch * num_steps + idx) // config.TRAIN.ACCUMULATION_STEPS)
         loss_scale_value = loss_scaler.state_dict()["scale"]
 
         with torch.no_grad():
@@ -355,15 +359,16 @@ def train_one_epoch_distill_using_saved_logits(args, config, model, criterion, d
         loss = loss / config.TRAIN.ACCUMULATION_STEPS
 
         # this attribute is added by timm on one optimizer (adahessian)
-        is_second_order = hasattr(optimizer, 'is_second_order') and optimizer.is_second_order
+        is_second_order = hasattr(
+            optimizer, 'is_second_order') and optimizer.is_second_order
         grad_norm = loss_scaler(loss, optimizer, clip_grad=config.TRAIN.CLIP_GRAD,
                                 parameters=model.parameters(), create_graph=is_second_order,
                                 update_grad=(idx + 1) % config.TRAIN.ACCUMULATION_STEPS == 0)
         if (idx + 1) % config.TRAIN.ACCUMULATION_STEPS == 0:
             optimizer.zero_grad()
-            lr_scheduler.step_update((epoch * num_steps + idx) // config.TRAIN.ACCUMULATION_STEPS)
+            lr_scheduler.step_update(
+                (epoch * num_steps + idx) // config.TRAIN.ACCUMULATION_STEPS)
         loss_scale_value = loss_scaler.state_dict()["scale"]
-
 
         # compute accuracy
         real_batch_size = len(original_targets)

--- a/TinyViT/main.py
+++ b/TinyViT/main.py
@@ -116,7 +116,7 @@ def main(args, config):
         flops = model_without_ddp.flops()
         logger.info(f"number of GFLOPs: {flops / 1e9}")
 
-    lr_scheduler = build_scheduler(config, optimizer, len(data_loader_train))
+    lr_scheduler = build_scheduler(config, optimizer, len(data_loader_train) // config.TRAIN.ACCUMULATION_STEPS)
 
     if config.DISTILL.ENABLED:
         # we disable MIXUP and CUTMIX when knowledge distillation

--- a/TinyViT/main.py
+++ b/TinyViT/main.py
@@ -207,6 +207,12 @@ def main(args, config):
     logger.info('Training time {}'.format(total_time_str))
 
 
+def is_valid_grad_norm(num):
+    if num is None:
+        return False
+    return not bool(torch.isinf(num)) and not bool(torch.isnan(num))
+
+
 def set_bn_state(config, model):
     if config.TRAIN.EVAL_BN_WHEN_TRAINING:
         for m in model.modules():
@@ -266,7 +272,7 @@ def train_one_epoch(args, config, model, criterion, data_loader, optimizer, epoc
         torch.cuda.synchronize()
 
         loss_meter.update(loss.item(), targets.size(0))
-        if grad_norm is not None:  # loss_scaler return None if not update
+        if is_valid_grad_norm(grad_norm):
             norm_meter.update(grad_norm)
         scaler_meter.update(loss_scale_value)
         batch_time.update(time.time() - end)
@@ -372,7 +378,7 @@ def train_one_epoch_distill_using_saved_logits(args, config, model, criterion, d
         torch.cuda.synchronize()
 
         loss_meter.update(loss.item(), real_batch_size)
-        if grad_norm is not None:  # loss_scaler return None if not update
+        if is_valid_grad_norm(grad_norm):
             norm_meter.update(grad_norm)
         scaler_meter.update(loss_scale_value)
         batch_time.update(time.time() - end)

--- a/TinyViT/save_logits.py
+++ b/TinyViT/save_logits.py
@@ -25,7 +25,7 @@ from config import get_config
 from models import build_model
 from data import build_loader
 from logger import create_logger
-from utils import load_checkpoint
+from utils import load_checkpoint, NativeScalerWithGradNormCount
 
 from models.remap_layer import RemapLayer
 remap_layer_22kto1k = RemapLayer('./imagenet_1kto22k.txt')
@@ -100,7 +100,8 @@ def main(config):
     lr_scheduler = None
 
     assert config.MODEL.RESUME
-    load_checkpoint(config, model_without_ddp, optimizer, lr_scheduler, logger)
+    loss_scaler = NativeScalerWithGradNormCount()
+    load_checkpoint(config, model_without_ddp, optimizer, lr_scheduler, loss_scaler, logger)
     if not args.skip_eval and not args.check_saved_logits:
         acc1, acc5, loss = validate(config, data_loader_val, model)
         logger.info(

--- a/TinyViT/save_logits.py
+++ b/TinyViT/save_logits.py
@@ -54,7 +54,8 @@ def parse_option():
                         help="gradient accumulation steps")
     parser.add_argument('--use-checkpoint', action='store_true',
                         help="whether to use gradient checkpointing to save memory")
-    parser.add_argument('--disable_amp', action='store_true', help='Disable pytorch amp')
+    parser.add_argument('--disable_amp', action='store_true',
+                        help='Disable pytorch amp')
     parser.add_argument('--output', default='output', type=str, metavar='PATH',
                         help='root of output folder, the full path is <output>/<model_name>/<tag> (default: output)')
     parser.add_argument('--tag', help='tag of experiment')
@@ -101,7 +102,8 @@ def main(config):
 
     assert config.MODEL.RESUME
     loss_scaler = NativeScalerWithGradNormCount()
-    load_checkpoint(config, model_without_ddp, optimizer, lr_scheduler, loss_scaler, logger)
+    load_checkpoint(config, model_without_ddp, optimizer,
+                    lr_scheduler, loss_scaler, logger)
     if not args.skip_eval and not args.check_saved_logits:
         acc1, acc5, loss = validate(config, data_loader_val, model)
         logger.info(

--- a/TinyViT/utils.py
+++ b/TinyViT/utils.py
@@ -260,7 +260,8 @@ def ampscaler_get_grad_norm(parameters, norm_type: float = 2.0) -> torch.Tensor:
         return torch.tensor(0.)
     device = parameters[0].grad.device
     if norm_type == inf:
-        total_norm = max(p.grad.detach().abs().max().to(device) for p in parameters)
+        total_norm = max(p.grad.detach().abs().max().to(device)
+                         for p in parameters)
     else:
         total_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(),
                                                         norm_type).to(device) for p in parameters]), norm_type)
@@ -278,7 +279,8 @@ class NativeScalerWithGradNormCount:
         if update_grad:
             if clip_grad is not None:
                 assert parameters is not None
-                self._scaler.unscale_(optimizer)  # unscale the gradients of optimizer's assigned params in-place
+                # unscale the gradients of optimizer's assigned params in-place
+                self._scaler.unscale_(optimizer)
                 norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad)
             else:
                 self._scaler.unscale_(optimizer)

--- a/TinyViT/utils.py
+++ b/TinyViT/utils.py
@@ -11,14 +11,8 @@ import torch
 import torch.distributed as dist
 import subprocess
 
-try:
-    # noinspection PyUnresolvedReferences
-    from apex import amp
-except ImportError:
-    amp = None
 
-
-def load_checkpoint(config, model, optimizer, lr_scheduler, logger):
+def load_checkpoint(config, model, optimizer, lr_scheduler, loss_scaler, logger):
     logger.info(
         f"==============> Resuming form {config.MODEL.RESUME}....................")
     if config.MODEL.RESUME.startswith('https'):
@@ -61,8 +55,8 @@ def load_checkpoint(config, model, optimizer, lr_scheduler, logger):
                 optimizer.load_state_dict(checkpoint['optimizer'])
             if lr_scheduler is not None:
                 lr_scheduler.load_state_dict(checkpoint['lr_scheduler'])
-            if 'amp' in checkpoint and config.AMP_OPT_LEVEL != "O0" and checkpoint['config'].AMP_OPT_LEVEL != "O0":
-                amp.load_state_dict(checkpoint['amp'])
+            if 'scaler' in checkpoint:
+                loss_scaler.load_state_dict(checkpoint['scaler'])
             logger.info(
                 f"=> loaded successfully '{config.MODEL.RESUME}' (epoch {checkpoint['epoch']})")
             if 'max_accuracy' in checkpoint:
@@ -206,15 +200,14 @@ def load_pretrained(config, model, logger):
     torch.cuda.empty_cache()
 
 
-def save_checkpoint(config, epoch, model, max_accuracy, optimizer, lr_scheduler, logger):
+def save_checkpoint(config, epoch, model, max_accuracy, optimizer, lr_scheduler, loss_scaler, logger):
     save_state = {'model': model.state_dict(),
                   'optimizer': optimizer.state_dict(),
                   'lr_scheduler': lr_scheduler.state_dict(),
                   'max_accuracy': max_accuracy,
+                  'scaler': loss_scaler.state_dict(),
                   'epoch': epoch,
                   'config': config}
-    if config.AMP_OPT_LEVEL != "O0":
-        save_state['amp'] = amp.state_dict()
 
     save_path = os.path.join(config.OUTPUT, f'ckpt_epoch_{epoch}.pth')
     logger.info(f"{save_path} saving......")
@@ -256,6 +249,51 @@ def reduce_tensor(tensor, n=None):
     dist.all_reduce(rt, op=dist.ReduceOp.SUM)
     rt = rt / n
     return rt
+
+
+def ampscaler_get_grad_norm(parameters, norm_type: float = 2.0) -> torch.Tensor:
+    if isinstance(parameters, torch.Tensor):
+        parameters = [parameters]
+    parameters = [p for p in parameters if p.grad is not None]
+    norm_type = float(norm_type)
+    if len(parameters) == 0:
+        return torch.tensor(0.)
+    device = parameters[0].grad.device
+    if norm_type == inf:
+        total_norm = max(p.grad.detach().abs().max().to(device) for p in parameters)
+    else:
+        total_norm = torch.norm(torch.stack([torch.norm(p.grad.detach(),
+                                                        norm_type).to(device) for p in parameters]), norm_type)
+    return total_norm
+
+
+class NativeScalerWithGradNormCount:
+    state_dict_key = "amp_scaler"
+
+    def __init__(self):
+        self._scaler = torch.cuda.amp.GradScaler()
+
+    def __call__(self, loss, optimizer, clip_grad=None, parameters=None, create_graph=False, update_grad=True):
+        self._scaler.scale(loss).backward(create_graph=create_graph)
+        if update_grad:
+            if clip_grad is not None:
+                assert parameters is not None
+                self._scaler.unscale_(optimizer)  # unscale the gradients of optimizer's assigned params in-place
+                norm = torch.nn.utils.clip_grad_norm_(parameters, clip_grad)
+            else:
+                self._scaler.unscale_(optimizer)
+                norm = ampscaler_get_grad_norm(parameters)
+            self._scaler.step(optimizer)
+            self._scaler.update()
+        else:
+            norm = None
+        return norm
+
+    def state_dict(self):
+        return self._scaler.state_dict()
+
+    def load_state_dict(self, state_dict):
+        self._scaler.load_state_dict(state_dict)
 
 
 def is_main_process():


### PR DESCRIPTION
Machine: 8 * V100

Model | Acc@1 (torch amp) | Training Time (torch amp) | Acc@1 (apex) | Training Time (apex) | Paper
--|--|--|--|--|--
TInyViT-21M-1k | 83.2 | 1d11h | 83.1 | 1d20h | 83.1
TinyViT-11M-1k | 81.4 | 1d7h | 81.5 | 1d9h | 81.5
TinyViT-5M-1k | 79.5 | 1d7h | 79.4 | 1d9h | 79.1

Acc Error: 0.1~0.2