### PR TITLE
[TinyViT Bug Fix] fix soft target cross entropy loss

### DIFF
--- a/TinyViT/main.py
+++ b/TinyViT/main.py
@@ -124,7 +124,7 @@ def main(args, config):
         # we disable MIXUP and CUTMIX when knowledge distillation
         assert len(
             config.DISTILL.TEACHER_LOGITS_PATH) > 0, "Please fill in DISTILL.TEACHER_LOGITS_PATH"
-        criterion = torch.nn.CrossEntropyLoss(reduction='mean')
+        criterion = SoftTargetCrossEntropy()
     else:
         if config.AUG.MIXUP > 0.:
             # smoothing is handled with mixup label transform


### PR DESCRIPTION
In the old version of PyTorch, `torch.nn.CrossEntropyLoss` does not accept soft label as the input.
Related issue: #131 

I replace it with an equivalent class.

Test code:
```python
import torch
from timm.loss import SoftTargetCrossEntropy

criterion = torch.nn.CrossEntropyLoss(reduction='mean')

def soft_cross_entropy(predicts, targets_prob):
    student_likelihood = torch.nn.functional.log_softmax(predicts, dim=-1)
    loss_batch = torch.sum(- targets_prob * student_likelihood, dim=-1)

    return loss_batch.mean()

a = torch.rand(3, 5)
b = torch.softmax(torch.rand(3, 5), dim=-1)
loss = criterion(a, b)
print(loss)
loss2 = soft_cross_entropy(a, b)
print(loss2)
loss3 = SoftTargetCrossEntropy()(a, b)
print(loss3)
```